### PR TITLE
[POR-14] split curp validation to webhook (inscription process)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { RouterModule } from '@nestjs/core';
 import { UtilsModule } from './utils/utils.module';
 import { SalesforceModule } from './salesforce/salesforce.module';
 import { EnrollmentModule } from './enrollment/enrollment.module';
+import { CurpModule } from './curp/curp.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { EnrollmentModule } from './enrollment/enrollment.module';
     ]),
     UtilsModule,
     EnrollmentModule,
+    CurpModule,
     
   ],
   controllers: [ AppController ],

--- a/src/curp/curp.controller.spec.ts
+++ b/src/curp/curp.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CurpController } from './curp.controller';
+
+describe('CurpController', () => {
+  let controller: CurpController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CurpController],
+    }).compile();
+
+    controller = module.get<CurpController>(CurpController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/curp/curp.controller.ts
+++ b/src/curp/curp.controller.ts
@@ -1,4 +1,28 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, Req, Res } from '@nestjs/common';
+import { CurpService } from './curp.service';
+import { catchError } from 'rxjs';
 
 @Controller('curp')
-export class CurpController {}
+export class CurpController {
+    constructor(private readonly curpService: CurpService) { }
+
+    @Post('/validate')
+    webhook(@Req() request: any, @Res() response: any) {
+        const ParamsHasError = !request.body.curp
+        const ParamsError = `Missing parameters: ${request.body.curp ? '' : 'curp, please check call.'}`
+        if (ParamsHasError) return response.status(400).send(ParamsError)
+        const curp = this.curpService.validateCURP(request.body.curp)
+        if (curp) {
+            this.curpService.fetchCURP(curp).pipe(
+                catchError((err, caught) => {
+                    response.status(err.response.data.status).send(err.response.data.message)
+                    return caught
+                })
+            ).subscribe(res => {
+                return response.status(200).send({ ...res.data })
+            })
+        } else {
+            return response.status(400).send("CURP is invalid, please check params")
+        }
+    }
+}

--- a/src/curp/curp.controller.ts
+++ b/src/curp/curp.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('curp')
+export class CurpController {}

--- a/src/curp/curp.module.ts
+++ b/src/curp/curp.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CurpController } from './curp.controller';
+import { CurpService } from './curp.service';
+import { CurpController } from './curp.controller';
+
+@Module({
+  controllers: [CurpController],
+  providers: [CurpService]
+})
+export class CurpModule {}

--- a/src/curp/curp.module.ts
+++ b/src/curp/curp.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CurpController } from './curp.controller';
 import { CurpService } from './curp.service';
-import { CurpController } from './curp.controller';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
+  imports:[ HttpModule ],
   controllers: [CurpController],
   providers: [CurpService]
 })

--- a/src/curp/curp.service.spec.ts
+++ b/src/curp/curp.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CurpService } from './curp.service';
+
+describe('CurpService', () => {
+  let service: CurpService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CurpService],
+    }).compile();
+
+    service = module.get<CurpService>(CurpService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/curp/curp.service.ts
+++ b/src/curp/curp.service.ts
@@ -1,4 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common'
+import { HttpService } from '@nestjs/axios';
+import { env } from 'process';
 
 @Injectable()
-export class CurpService {}
+export class CurpService {
+    constructor(private http: HttpService) { }
+
+    validateCURP(curp: string) {
+        const validatorCURP = /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/
+        return validatorCURP.test(curp) ? curp : null
+    }
+
+    fetchCURP(curp: string) {
+        const data = {
+            idEndPoint: env.CURP_VALIDATION_ID_END_POINT,
+            params: [{                
+                "name": "curp",
+                "value": curp
+            }]
+        };
+        return this.http.post(env.CURP_VALIDATION_URL, data, {
+            headers: {
+                'PublicApiKey': env.CURP_VALIDATION_API_KEY
+            }
+        })
+    }
+}

--- a/src/curp/curp.service.ts
+++ b/src/curp/curp.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CurpService {}


### PR DESCRIPTION
## Issue
Dev the webhook to get CURP data from renapo API

## Solution
- [X] post curp using validate and fetch 6b651c8
- [X] define services and controller ae7d2fd
- [X] dev fetch and validate curp c3c1c57

## Testing
1. Start server with yarn start:dev
2. Go to postman 
3. POST raw json body of curp {"curp":"CURP"}
4. See response on the console 
5. Enjoy 🌮